### PR TITLE
Introduce argument parsing, change default file location

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,85 @@
+use std::ffi::CStr;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Args {
+    pub debug: bool,
+    pub file: String,
+}
+
+impl Args {
+    pub fn parse(args: Vec<&CStr>) -> Self {
+        let mut debug = false;
+        let mut file: String = "/etc/security/authorized_keys".into();
+
+        for arg in args
+            .iter()
+            .map(|s| s.to_bytes())
+            .map(String::from_utf8_lossy)
+        {
+            if arg == "debug" {
+                debug = true;
+            }
+            if let Some(s) = arg.strip_prefix("file=") {
+                file = s.into();
+            }
+        }
+        Args { debug, file }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::args::Args;
+    use std::ffi::{CStr, CString};
+
+    struct CStrings {
+        inner: Vec<CString>,
+    }
+
+    impl CStrings {
+        fn refs(&self) -> Vec<&CStr> {
+            self.inner
+                .iter()
+                .map(CString::as_ref)
+                .collect::<Vec<&CStr>>()
+        }
+    }
+
+    macro_rules! args {
+        () => {
+            CStrings {inner: Vec::new() }
+        };
+        ( $( $x:tt ),+ ) => {
+            {
+                let inner: Vec<CString> = vec![$( $x ),+].iter()
+                    .map(|s| CString::new(*s).expect("CString::new failed"))
+                    .collect();
+                CStrings {inner}
+            }
+        };
+    }
+
+    #[test]
+    fn test_parse() {
+        let expected = Args {
+            debug: false,
+            file: "/etc/security/authorized_keys".into(),
+        };
+        assert_eq!(expected, Args::parse(args!().refs()));
+
+        let expected = Args {
+            debug: true,
+            file: "/etc/security/authorized_keys".into(),
+        };
+        assert_eq!(expected, Args::parse(args!("debug").refs()));
+
+        let expected = Args {
+            debug: true,
+            file: "/dev/null".into(),
+        };
+        assert_eq!(
+            expected,
+            Args::parse(args!("debug", "file=/dev/null").refs())
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod agent;
+mod args;
 mod auth;
 mod keys;
+mod syslog;
 
 pub use crate::agent::SSHAgent;
 pub use crate::auth::authenticate;
@@ -9,14 +11,12 @@ use std::env;
 use pam::constants::{PamFlag, PamResultCode};
 use pam::module::{PamHandle, PamHooks};
 
+use crate::syslog::SyslogLogger;
 use anyhow::{anyhow, Context, Result};
+use args::Args;
 use ssh_agent_client_rs::Client;
 use std::ffi::CStr;
-use std::fmt::Display;
 use std::path::Path;
-
-use pam::items::Service;
-use syslog::{Facility, Formatter3164, Logger, LoggerBackend};
 
 struct PamSshAgent;
 pam::pam_hooks!(PamSshAgent);
@@ -24,12 +24,13 @@ pam::pam_hooks!(PamSshAgent);
 impl PamHooks for PamSshAgent {
     fn sm_authenticate(
         pam_handle: &mut PamHandle,
-        _args: Vec<&CStr>,
+        args: Vec<&CStr>,
         _flags: PamFlag,
     ) -> PamResultCode {
         let mut log = SyslogLogger::new(pam_handle);
+        let args = Args::parse(args);
 
-        match do_authenticate(&mut log) {
+        match do_authenticate(&mut log, &args) {
             Ok(_) => PamResultCode::PAM_SUCCESS,
             Err(err) => {
                 for line in format!("{err:?}").split('\n') {
@@ -51,60 +52,13 @@ impl PamHooks for PamSshAgent {
     }
 }
 
-fn do_authenticate(log: &mut SyslogLogger) -> Result<()> {
+fn do_authenticate(log: &mut SyslogLogger, args: &Args) -> Result<()> {
     let path = env::var("SSH_AUTH_SOCK")
         .context("Required environment variable SSH_AUTH_SOCK is not set")?;
     log.info(format!("Authenticating using ssh-agent at '{path}'"))?;
     let ssh_agent_client = Client::connect(Path::new(path.as_str()))?;
-    match authenticate("/etc/sudo_ssh_keys", ssh_agent_client)? {
+    match authenticate(args.file.as_str(), ssh_agent_client)? {
         true => Ok(()),
         false => Err(anyhow!("Agent did not know of any of the allowed keys")),
     }
-}
-
-// Just a quick hack to get logging into syslog. Longer term,
-// this should be done in pam-bindings: https://github.com/anowell/pam-rs/pull/12
-
-const PREFIX: &str = "pam_ssh_agent({}:auth): ";
-
-struct SyslogLogger {
-    log: Logger<LoggerBackend, Formatter3164>,
-    prefix: String,
-}
-
-impl SyslogLogger {
-    fn new(pam_handle: &PamHandle) -> Self {
-        match syslog::unix(Formatter3164 {
-            facility: Facility::LOG_AUTHPRIV,
-            hostname: None,
-            process: String::from("unknown"),
-            pid: std::process::id(),
-        }) {
-            Ok(log) => SyslogLogger {
-                log,
-                prefix: format!("pam_ssh_agent({}:auth): ", get_service(pam_handle)),
-            },
-            Err(e) => panic!("Failed to create syslog: {e:?}"),
-        }
-    }
-
-    fn info<S: Display>(&mut self, message: S) -> Result<()> {
-        self.log
-            .info(format!("{}{}", self.prefix, message))
-            .map_err(|e| anyhow!("failed to log: {e:?}"))
-    }
-
-    fn error<S: Display>(&mut self, message: S) -> Result<()> {
-        self.log
-            .err(format!("{PREFIX}{message}"))
-            .map_err(|e| anyhow!("failed to log: {e:?}"))
-    }
-}
-
-fn get_service(pam_handle: &PamHandle) -> String {
-    let service = match pam_handle.get_item::<Service>() {
-        Ok(Some(conv)) => conv,
-        _ => panic!("Can't find service"),
-    };
-    String::from_utf8(service.0.to_bytes().to_vec()).expect("Service name not valid utf-8")
 }

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -1,0 +1,59 @@
+// Just a quick hack to get logging into syslog. Longer term,
+// this should be done in pam-bindings: https://github.com/anowell/pam-rs/pull/12
+
+use anyhow::{anyhow, Result};
+use pam::items::Service;
+use pam::module::PamHandle;
+use std::env;
+use std::fmt::Display;
+use syslog::{Facility, Formatter3164, Logger, LoggerBackend};
+
+pub struct SyslogLogger {
+    log: Logger<LoggerBackend, Formatter3164>,
+    prefix: String,
+}
+
+impl SyslogLogger {
+    pub(crate) fn new(pam_handle: &PamHandle) -> Self {
+        match syslog::unix(Formatter3164 {
+            facility: Facility::LOG_AUTHPRIV,
+            hostname: None,
+            process: process_name().unwrap_or("unknown".into()),
+            pid: std::process::id(),
+        }) {
+            Ok(log) => SyslogLogger {
+                log,
+                prefix: format!("pam_ssh_agent({}:auth): ", get_service(pam_handle)),
+            },
+            Err(e) => panic!("Failed to create syslog: {:?}", e),
+        }
+    }
+
+    pub fn info<S: Display>(&mut self, message: S) -> Result<()> {
+        self.log
+            .info(format!("{}{}", self.prefix, message))
+            .map_err(|e| anyhow!("failed to log: {:?}", e))
+    }
+
+    pub fn error<S: Display>(&mut self, message: S) -> Result<()> {
+        self.log
+            .err(format!("{}{}", self.prefix, message))
+            .map_err(|e| anyhow!("failed to log: {:?}", e))
+    }
+}
+
+fn get_service(pam_handle: &PamHandle) -> String {
+    let service = match pam_handle.get_item::<Service>() {
+        Ok(Some(service)) => service,
+        _ => return "unknown".into(),
+    };
+    String::from_utf8_lossy(service.0.to_bytes()).to_string()
+}
+
+fn process_name() -> Result<String> {
+    Ok(env::current_exe()?
+        .file_name()
+        .ok_or(anyhow!("no filename"))?
+        .to_string_lossy()
+        .into())
+}


### PR DESCRIPTION
This change introduces parsing of module arguments from the pam config file, and changes the default filename used to read the authorized keys.