### PR TITLE
auth: Fix multiple 'sk' keys configured, fails on first

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -16,17 +16,17 @@ pub struct PrintLog;
 
 impl Log for PrintLog {
     fn debug<S: Display>(&mut self, message: S) -> Result<()> {
-        print!("DEBUG: {}", message);
+        println!("DEBUG: {}", message);
         Ok(())
     }
 
     fn info<S: Display>(&mut self, message: S) -> Result<()> {
-        print!("INFO: {}", message);
+        println!("INFO: {}", message);
         Ok(())
     }
 
     fn error<S: Display>(&mut self, message: S) -> Result<()> {
-        print!("ERROR: {}", message);
+        println!("ERROR: {}", message);
         Ok(())
     }
 }

--- a/tests/data/authorized_keys_with_sk
+++ b/tests/data/authorized_keys_with_sk
@@ -1,0 +1,2 @@
+sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIELiu0pRxI/SHnpQOhs2UyKsg6OMpdwYfxKgySAyQhIzAAAABHNzaDo= test_sk@localhost
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIObUcRy1Nv6fz4xnAXqOaFL/A+gGM9OF+l2qpsDPmMlU test@ed25519

--- a/tests/data/test_ed25519_sk.pub
+++ b/tests/data/test_ed25519_sk.pub
@@ -1,0 +1,1 @@
+sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIELiu0pRxI/SHnpQOhs2UyKsg6OMpdwYfxKgySAyQhIzAAAABHNzaDo= test_sk@localhost

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -33,8 +33,5 @@ fn test_roundtrip() {
     // Yes, it is a bit weird that compile time paths resolve from this dir but run time
     // paths resolve from the top dir. I'll come up with a better solution later.
     let auth_keys = "tests/data/authorized_keys";
-    assert_eq!(
-        true,
-        authenticate(auth_keys, agent, &mut PrintLog {}).unwrap()
-    )
+    assert!(authenticate(auth_keys, agent, &mut PrintLog {}).unwrap())
 }

--- a/tests/sk_not_present.rs
+++ b/tests/sk_not_present.rs
@@ -1,0 +1,53 @@
+use pam_ssh_agent::{authenticate, PrintLog, SSHAgent};
+use signature::Signer;
+use ssh_agent_client_rs::Error as SACError;
+use ssh_key::{Algorithm, PrivateKey, PublicKey, Signature};
+
+struct DummySshAgent {
+    key: PrivateKey,
+}
+
+// Generated with `ssh-keygen -t ed25519-sk -f test_ed25519_sk -C test_sk@localhost`
+// with a Yubikey 5c
+const PUBLIC_SK_KEY: &str = include_str!("data/test_ed25519_sk.pub");
+
+const PRIVATE_KEY: &str = include_str!("data/id_ed25519");
+const PUBLIC_KEY: &str = include_str!("data/id_ed25519.pub");
+
+impl DummySshAgent {
+    fn new() -> DummySshAgent {
+        let key = PrivateKey::from_openssh(PRIVATE_KEY).expect("Failed to parse test key");
+
+        DummySshAgent { key }
+    }
+}
+
+impl SSHAgent for DummySshAgent {
+    fn list_identities(&mut self) -> ssh_agent_client_rs::Result<Vec<PublicKey>> {
+        let pubkeys: Vec<PublicKey> = [
+            PublicKey::from_openssh(PUBLIC_SK_KEY).expect("Failed to parse sk pubkey"),
+            PublicKey::from_openssh(PUBLIC_KEY).expect("Failed to parse test pubkey"),
+        ]
+        .to_vec();
+
+        Ok(pubkeys)
+    }
+
+    fn sign(&mut self, pubkey: &PublicKey, data: &[u8]) -> ssh_agent_client_rs::Result<Signature> {
+        if pubkey.algorithm() == Algorithm::SkEd25519 {
+            return Err(SACError::RemoteFailure);
+        }
+        Ok(self.key.key_data().sign(data.as_ref()))
+    }
+}
+
+#[test]
+fn test_sk_not_present() {
+    let agent = DummySshAgent::new();
+    let auth_keys = "tests/data/authorized_keys_with_sk";
+
+    // exercise an 'sk' (hardware) key being authorized, but not present.  Correct behavior is to
+    // catch the RemoteFailure SSHAgent error on the 'sk' key, and try the next key, which will
+    // succeed.
+    assert!(authenticate(auth_keys, agent, &mut PrintLog {}).unwrap())
+}


### PR DESCRIPTION
When a user has configured two or more 'sk' keys, eg Yubikeys, pam-ssh-agent will fail if the first configured key isn't currently plugged in.

Standard SSH utilities gracefully try the next key in this situation, so we should too.  This is very helpful for users attempting to dogfood their backup key.  ;-)

We correct this failure by catching the error, and trying the next key IFF the failed key was of the 'sk' type.