### PR TITLE
Update all deps to latest stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,11 @@ name = "pam_ssh_agent"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-ssh-agent-client-rs = "0.9.0"
-getrandom = "0.2.10"
-ssh-key = { version = "0.6.2", features = ["crypto"] }
+ssh-agent-client-rs = "0.9.1"
+getrandom = "0.2.13"
+ssh-key = { version = "0.6.5", features = ["crypto"] }
 # we need the signature that ssh-key uses
-signature = "2.1.0"
-anyhow = "1.0.75"
+signature = "2.2.0"
+anyhow = "1.0.81"
 pam-bindings = "0.1.1"
 syslog = "6.1.0"
-
-# Since we are building on ubuntu 2022.04, we need to downgrade this
-# to a version that supports the compiler
-time = "0.3.30"


### PR DESCRIPTION
Most significantly, this brings in ssh-agent-client-rs 0.9.1 which adds support for sk-ecdsa keys.

Also, since Ubuntu updates has brought in a more recent rust toolchain, there is no longer a need to pin the time crate