### PR TITLE
Two clippy warnings: lifetime simplifcation, single char split

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -44,7 +44,7 @@ impl Args {
                         None => Cow::from(any),
                     };
 
-                    let parts: Vec<&str> = any.splitn(2, "=").collect();
+                    let parts: Vec<&str> = any.splitn(2, '=').collect();
                     if parts.len() != 2 {
                         return Err(anyhow!("Could not split '{any}' using '='"));
                     }

--- a/src/expansions.rs
+++ b/src/expansions.rs
@@ -27,7 +27,7 @@ impl<'a> UnixEnvironment<'a> {
     }
 }
 
-impl<'a> Environment for UnixEnvironment<'a> {
+impl Environment for UnixEnvironment<'_> {
     fn get_homedir(&self, user: &str) -> Result<Cow<str>> {
         match get_user_by_name(user) {
             Some(user) => Ok(Cow::Owned(user.home_dir().to_string_lossy().to_string())),


### PR DESCRIPTION
These changes were suggested by the clippy execution on github, at some point I would like to figure out why I don't see this locally