### PR TITLE
Debian build fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bitflags"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+CARGO_VERSION = 1.82
 build:
-	cargo build --release
+	cargo-$(CARGO_VERSION) build --release
 	strip target/release/libpam_ssh_agent.so
 
 install:
@@ -7,13 +8,16 @@ install:
 		$(DESTDIR)/lib/${DEB_HOST_MULTIARCH}/security/pam_ssh_agent.so
 
 clean:
-	cargo clean
+	cargo-$(CARGO_VERSION) clean
 
 
 check:
-	cargo fmt --check
-	cargo clippy
-	cargo test
+	cargo-$(CARGO_VERSION) fmt --check
+	# it seems the packaging of rust-1.82 and friends is a bit funky
+	# if the PATH is not set when invoking clippy and test, the old
+	# version will be used
+	PATH=/usr/lib/rust-$(CARGO_VERSION)/bin:$(PATH) cargo-$(CARGO_VERSION) clippy
+	PATH=/usr/lib/rust-$(CARGO_VERSION)/bin:$(PATH) cargo-$(CARGO_VERSION) test
 
 srpm:
 	echo "BUILD: create SRPM like COPR is doing"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pam-ssh-agent (0.9.0) UNRELEASED; urgency=medium
+
+  * Build fixes etc
+
+ -- Noa Resare <noa@resare.com>  Sun, 6 Jul 2025 21:39:51 +0000
+
 pam-ssh-agent (0.5.1) UNRELEASED; urgency=medium
 
   * Add support for configuring the path to the ssh-agent socket

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,9 @@
 Source: pam-ssh-agent
 Section: libs
 Priority: optional
-Maintainer: Noa <noa@resare.com>
+Maintainer: Noa Resare <noa@resare.com>
 Build-Depends: debhelper,
-        libpam0g-dev, cargo, rustfmt, rust-clippy
+        libpam0g-dev, cargo-1.82, rustfmt-1.82, rust-1.82-clippy
 Standards-Version: 4.6.0
 Homepage: https://github.com/nresare/pam-ssh-agent
 Rules-Requires-Root: no


### PR DESCRIPTION
Debian now ships with rustc/cargo 1.82 so let's use that and get away from needing to generate Cargo.lock with 1.75

However, since 1.85 still have not been released, we need to downgrade base64tc as the most recent stable requires edition 2024