### PR TITLE
Implement authorized_keys_command, and some other minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,23 @@ timely manner. A secondary benefit is that it is easier to support a wide range 
 ## Configuration options
 
 PAM modules can be configured using space separated options after `pam_ssh_agent.so` in the applicable
-configuration file in `/etc/pam.d`. pam_ssh_agent currently understands the following options
+configuration file in `/etc/pam.d`. pam_ssh_agent currently understands the following options:
 
-* `debug` This will increase log output to the AUTHPRIV syslog facility
-* `file=/file/name` This will modify the file holding the authorized public keys instead of the
-  default `/etc/security/authorized_keys`. This path is subject to the variable expansions mentioned below
-* `ca_keys_file=/ca/keys/filename`. The file at this path, if specified, will be expected to contain lines with
-  ssh keys that are considered trusted certificate authority keys. See below for further information
-  about certificate authentication and the subtle format difference in file format compared to `file`
-* `default_ssh_auth_sock=/path/to/ssh_agent_unix_socket` the path to use if the `SSH_AUTH_SOCKET` is not
-  set
+* `debug` Increase log output to the AUTHPRIV syslog facility.
+* `file=/file/name` Override/modify the file from which authorized public keys are read. If not
+  specified, the default is `/etc/security/authorized_keys`. This path is subject to the variable
+  expansions mentioned below.
+* `ca_keys_file=/ca/keys/filename` Read trusted certificate authorities from a file that doesn't
+  include any key options prefixes. See below for further information about certificate
+  authentication and the subtle format difference in file format compared to `file`.
+* `authorized_keys_command=/path/executable` Specify a command that should be run to dynamically
+  retrieve/prepare a list of authorized public keys. The command will be passed a single argument
+  containing the username of the user requesting authentication. The command should print keys to
+  STDOUT in authorized_keys format.
+* `authorized_keys_command_user=nobody` Specify the user that `authorized_keys_command` will be
+  executed as. If not specified, the command will be run as the requesting user.
+* `default_ssh_auth_sock=/path/to/ssh_agent_unix_socket` Specify a default path to use if
+  `SSH_AUTH_SOCKET` is not set.
 
 ## SSH Certificates
 
@@ -75,7 +82,7 @@ that the key is prefixed with `cert-authority` followed by a space and the key i
 The second way to specify certificate authority keys work in the same way as the OpenSSH option `TrustedUserCAKeys`
 where keys without the `cert-authority` option are specified, one per line. To enable this mode of operation,
 set the `ca_keys_file` option.
-  
+
 ## Variable expansions
 
 > :warning: Using the home directory expansion is unsafe. It allows an attacker with access to an account with sudo

--- a/README.md
+++ b/README.md
@@ -90,21 +90,24 @@ set the `ca_keys_file` option.
 > sudo with the `NOPASSWD` option is a better option as it makes the insecure configuration explicit.
 
 It is possible to use variable expansion in any of the configuration options. In the current age of configuration
-management systems, it might make more sense to move the complexity of using the right `authorized_keys` file 
-to those systems, but these variable expansions are available to uses that might want them to provide a smooth upgrade
+management systems, it might make more sense to move the complexity of using the right `authorized_keys` file
+to those systems, but these variable expansions are available to users that might want them to provide a smooth upgrade
 path from `pam_ssh_agent_auth`.
 
-* `~` same as in shells, without specifying a username this expands to the home directory referred to by `PAM_RUSER`, 
-  normally the user attempting to authenticate. If a username is specified, the home directory of that user will be
-  used such that `~alice` might expand to `/home/alice`
-* `%h` same as `~`, the home directory of the user referred to by the PAM item `PAM_RUSER`
+* `~` same as in shells. If a username is not specified then this expands to the home directory of
+  the requesting user. If a username is specified then the home directory of that user will be used,
+  such that `~alice` will expand to `/home/alice`.
+* `%h` same as `~`, the home directory of the requesting user.
+* `%r` the username of the requesting user.
+* `%R` numeric UID of the requesting user.
+* `%m` the home directory of the target user.
+* `%u` the username of the target user.
+* `%U` numeric UID of the target user.
 * `%H` the value returned by `gethostname(3)`, truncated after the first period such that if `gethostname(3)` returns
-  `host.example.com` this `%H` will turn into `host`
+  `host.example.com` this `%H` will turn into `host`.
 * `%f` the value returned by `gethostname(3)`. For the systems I have looked at, this value is not a fully qualified
   domain name but if it was it would be returned. This behaviour, although a bit surprising is consistent with how
-  `pam_ssh_agent_auth` works
-* `%u` the username of the user attempting to authenticate
-* `%U` numeric uid of the user attempting to authenticate
+  `pam_ssh_agent_auth` works.
 
 ## The `native-crypto` feature
 

--- a/examples/authenticator.rs
+++ b/examples/authenticator.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use log::info;
-use pam_ssh_agent::authenticate;
+use pam_ssh_agent::{authenticate, args::Args};
 use ssh_agent_client_rs::Client;
 use std::env;
 use std::path::Path;
@@ -10,15 +10,20 @@ fn main() -> Result<()> {
     let client = Client::connect(Path::new(path.as_str()))?;
 
     let authorized_keys_path = env::args().nth(1).expect("argument missing");
+    let args = Args {
+        file: Some(authorized_keys_path),
+        ..Default::default()
+    };
 
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)
         .init();
-    let result = authenticate(authorized_keys_path.as_str(), None, client, "")?;
+    let result = authenticate(None, &args, client)?;
+    let file = args.file.unwrap();
     if result {
-        info!("the ssh agent at {path} signed a random message as validated by {authorized_keys_path}");
+        info!("the ssh agent at {path} signed a random message as validated by {file}");
     } else {
-        info!("No public key in {authorized_keys_path} could be used with the ssh-agent at {path}");
+        info!("No public key in {file} could be used with the ssh-agent at {path}");
     }
     Ok(())
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,18 +10,22 @@ const DEFAULT_AUTHORIZED_KEYS_PATH: &str = "/etc/security/authorized_keys";
 #[derive(Debug, Eq, PartialEq)]
 pub struct Args {
     pub debug: bool,
-    pub file: String,
-    pub default_ssh_auth_sock: Option<String>,
+    pub file: Option<String>,
     pub ca_keys_file: Option<String>,
+    pub keys_command: Option<String>,
+    pub command_user: Option<String>,
+    pub default_ssh_auth_sock: Option<String>,
 }
 
 impl Default for Args {
     fn default() -> Self {
         Args {
             debug: false,
-            file: String::from(DEFAULT_AUTHORIZED_KEYS_PATH),
-            default_ssh_auth_sock: None,
+            file: Some(String::from(DEFAULT_AUTHORIZED_KEYS_PATH)),
             ca_keys_file: None,
+            keys_command: None,
+            command_user: None,
+            default_ssh_auth_sock: None,
         }
     }
 }
@@ -30,9 +34,11 @@ impl Args {
     /// Parses args and returns an Args instance with the parsed arguments, if pam_handle
     pub fn parse(args: Vec<&CStr>, env: Option<&dyn Environment>) -> Result<Self> {
         let mut debug = false;
-        let mut file: String = String::from(DEFAULT_AUTHORIZED_KEYS_PATH);
-        let mut default_ssh_auth_sock = None;
+        let mut file: Option<String> = None;
         let mut ca_keys_file: Option<String> = None;
+        let mut keys_command: Option<String> = None;
+        let mut command_user: Option<String> = None;
+        let mut default_ssh_auth_sock: Option<String> = None;
 
         for arg in args
             .iter()
@@ -53,19 +59,26 @@ impl Args {
                     }
                     let (key, value) = (parts[0], parts[1]);
                     match key {
-                        "file" => file = value.to_string(),
-                        "default_ssh_auth_sock" => default_ssh_auth_sock = Some(value.to_string()),
+                        "file" => file = Some(value.to_string()),
                         "ca_keys_file" => ca_keys_file = Some(value.to_string()),
+                        "authorized_keys_command" => keys_command = Some(value.to_string()),
+                        "authorized_keys_command_user" => command_user = Some(value.to_string()),
+                        "default_ssh_auth_sock" => default_ssh_auth_sock = Some(value.to_string()),
                         _ => return Err(anyhow!("Unknown parameter key '{key}'")),
                     }
                 }
             }
         }
+        if ! [&file, &ca_keys_file, &keys_command].iter().any(|a| a.is_some()) {
+            file = Some(String::from(DEFAULT_AUTHORIZED_KEYS_PATH));
+        }
         Ok(Args {
             debug,
             file,
-            default_ssh_auth_sock,
             ca_keys_file,
+            keys_command,
+            command_user,
+            default_ssh_auth_sock,
         })
     }
 }
@@ -116,12 +129,22 @@ mod test {
 
         let expected = Args {
             debug: true,
-            file: "/dev/null".into(),
+            file: Some("/dev/null".into()),
             ..Default::default()
         };
         assert_eq!(
             expected,
             Args::parse(args!("debug", "file=/dev/null").refs(), None)?,
+        );
+
+        let expected = Args {
+            file: None,
+            keys_command: Some("/bin/true".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            expected,
+            Args::parse(args!("authorized_keys_command=/bin/true").refs(), None)?,
         );
 
         let expected = Args {

--- a/src/expansions.rs
+++ b/src/expansions.rs
@@ -108,8 +108,13 @@ pub fn expand_vars<'a>(input: &'a str, env: &'a dyn Environment) -> Result<Cow<'
     input = expand_var(input, "%h", || {
         env.get_homedir(env.get_requesting_username()?.as_ref())
     })?;
-    input = expand_var(input, "%u", || env.get_requesting_username())?;
-    input = expand_var(input, "%U", || env.get_uid(&env.get_requesting_username()?))?;
+    input = expand_var(input, "%r", || env.get_requesting_username())?;
+    input = expand_var(input, "%R", || env.get_uid(&env.get_requesting_username()?))?;
+    input = expand_var(input, "%m", || {
+        env.get_homedir(env.get_target_username()?.as_ref())
+    })?;
+    input = expand_var(input, "%u", || env.get_target_username())?;
+    input = expand_var(input, "%U", || env.get_uid(&env.get_target_username()?))?;
     input = expand_var(input, "%H", || env.get_hostname())?;
     input = expand_var(input, "%f", || env.get_fqdn())?;
     Ok(input)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,4 +1,4 @@
-use pam_ssh_agent::{authenticate, SSHAgent};
+use pam_ssh_agent::{authenticate, SSHAgent, args::Args};
 use signature::Signer;
 use ssh_agent_client_rs::Identity;
 use ssh_key::{PrivateKey, PublicKey, Signature};
@@ -36,12 +36,15 @@ impl SSHAgent for DummySshAgent {
 #[test]
 fn test_roundtrip() {
     let agent = DummySshAgent::new();
-    // Yes, it is a bit weird that compile time paths resolve from this dir but run time
-    // paths resolve from the top dir. I'll come up with a better solution later.
-    let auth_keys = "tests/data/authorized_keys";
+    let args = Args {
+        // Yes, it is a bit weird that compile time paths resolve from this dir but run time
+        // paths resolve from the top dir. I'll come up with a better solution later.
+        file: Some("tests/data/authorized_keys".into()),
+        ..Default::default()
+    };
     // logging for the test case
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)
         .init();
-    assert!(authenticate(auth_keys, None, agent, "").unwrap())
+    assert!(authenticate(None, &args, agent).unwrap())
 }

--- a/tests/sk_not_present.rs
+++ b/tests/sk_not_present.rs
@@ -1,4 +1,4 @@
-use pam_ssh_agent::{authenticate, SSHAgent};
+use pam_ssh_agent::{args::Args, authenticate, SSHAgent};
 use signature::Signer;
 use ssh_agent_client_rs::{Error as SACError, Identity};
 use ssh_key::{Algorithm, PrivateKey, PublicKey, Signature};
@@ -55,10 +55,13 @@ impl SSHAgent for DummySshAgent {
 #[test]
 fn test_sk_not_present() {
     let agent = DummySshAgent::new();
-    let auth_keys = "tests/data/authorized_keys_with_sk";
+    let args = Args {
+        file: Some("tests/data/authorized_keys_with_sk".into()),
+        ..Default::default()
+    };
 
     // exercise an 'sk' (hardware) key being authorized, but not present.  Correct behavior is to
     // catch the RemoteFailure SSHAgent error on the 'sk' key, and try the next key, which will
     // succeed.
-    assert!(authenticate(auth_keys, None, agent, "").unwrap())
+    assert!(authenticate(None, &args, agent).unwrap())
 }


### PR DESCRIPTION
For compatibility with pam_ssh_agent_auth, this PR implements `authorized_keys_command` and `authorized_keys_command_user`.

While I was changing things, I also changed the behavior of the `%u` expansion to match pam_ssh_agent_auth and added a few additional expansions, and I made error handling a bit more robust (eg. if there is a malformed key in a file, it should now reject only that one key instead of rejecting the whole file).

Some file path and ownership checks should probably also be implemented (similar to https://github.com/jbeverly/pam_ssh_agent_auth/blob/master/secure_filename.c ), but I haven't attempted to tackle that.