### PR TITLE
Move IdentityFilter to separate module, fix for new lints

### DIFF
--- a/examples/authenticator.rs
+++ b/examples/authenticator.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use log::info;
 use pam_ssh_agent::authenticate;
+use pam_ssh_agent::filter::IdentityFilter;
 use ssh_agent_client_rs::Client;
 use std::env;
 use std::path::Path;
@@ -14,7 +15,8 @@ fn main() -> Result<()> {
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)
         .init();
-    let result = authenticate(authorized_keys_path.as_str(), None, client, "")?;
+    let filter = IdentityFilter::from_files(Path::new(authorized_keys_path.as_str()), None)?;
+    let result = authenticate(&filter, client, "")?;
     if result {
         info!("the ssh agent at {path} signed a random message as validated by {authorized_keys_path}");
     } else {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,12 +1,10 @@
 pub use crate::agent::SSHAgent;
+use crate::filter::IdentityFilter;
 use crate::verify::verify;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use log::{debug, info};
 use ssh_agent_client_rs::{Error as SACError, Identity};
-use ssh_key::public::KeyData;
-use ssh_key::{AuthorizedKeys, HashAlg};
-use std::collections::HashSet;
-use std::path::Path;
+use ssh_key::HashAlg;
 use std::time::{SystemTime, UNIX_EPOCH};
 use Identity::{Certificate, PublicKey};
 
@@ -19,13 +17,10 @@ const CHALLENGE_SIZE: usize = 32;
 /// Returns Ok(true) if a key was found and the signature was correct, Ok(false) if no
 /// key was found, and Err if agent communication or signature verification failed.
 pub fn authenticate(
-    keys_file_path: &str,
-    ca_keys_file: Option<&str>,
+    filter: &IdentityFilter,
     mut agent: impl SSHAgent,
     principal: &str,
 ) -> Result<bool> {
-    let filter =
-        IdentityFilter::from_files(Path::new(keys_file_path), ca_keys_file.map(Path::new))?;
     for identity in agent.list_identities()? {
         if filter.filter(&identity) {
             if let Certificate(cert) = &identity {
@@ -63,63 +58,6 @@ fn sign_and_verify(identity: Identity<'static>, agent: &mut impl SSHAgent) -> Re
     Ok(true)
 }
 
-struct IdentityFilter {
-    keys: HashSet<KeyData>,
-    ca_keys: HashSet<KeyData>,
-}
-
-impl IdentityFilter {
-    fn from_files(path: &Path, ca_keys_file: Option<&Path>) -> Result<Self> {
-        let mut keys: HashSet<KeyData> = HashSet::new();
-        let mut ca_keys: HashSet<KeyData> = HashSet::new();
-
-        for entry in
-            AuthorizedKeys::read_file(path).context(format!("Failed to read from {path:?}"))?
-        {
-            let opts = entry.config_opts();
-            if opts.iter().any(|o| o == "cert-authority") {
-                ca_keys.insert(entry.public_key().key_data().to_owned());
-            } else {
-                keys.insert(entry.public_key().key_data().to_owned());
-            }
-        }
-
-        if let Some(key_path) = ca_keys_file {
-            for entry in AuthorizedKeys::read_file(key_path)
-                .context(format!("Failed to read trusted ca keys from {key_path:?}"))?
-            {
-                ca_keys.insert(entry.public_key().key_data().to_owned());
-            }
-        }
-        Ok(IdentityFilter { keys, ca_keys })
-    }
-
-    fn filter(&self, identity: &Identity) -> bool {
-        match identity {
-            PublicKey(key) => {
-                if self.keys.contains(key.key_data()) {
-                    debug!(
-                        "found a matching key: {}",
-                        key.fingerprint(Default::default())
-                    );
-                    return true;
-                }
-            }
-            Certificate(cert) => {
-                let ca_key = cert.signature_key();
-                if self.ca_keys.contains(ca_key) {
-                    debug!(
-                        "found a matching cert-authority key: {}",
-                        ca_key.fingerprint(Default::default())
-                    );
-                    return true;
-                }
-            }
-        }
-        false
-    }
-}
-
 fn validate_cert(cert: &ssh_key::Certificate, when: SystemTime, principal: &str) -> bool {
     let ca_key = cert.signature_key();
 
@@ -148,43 +86,11 @@ fn validate_cert(cert: &ssh_key::Certificate, when: SystemTime, principal: &str)
 
 #[cfg(test)]
 mod test {
-    use crate::auth::{validate_cert, IdentityFilter};
+    use crate::auth::validate_cert;
+    use crate::test::{data, CERT_STR};
     use anyhow::Result;
-    use ssh_agent_client_rs::Identity;
     use ssh_key::Certificate;
-    use std::path::Path;
     use std::time::{Duration, SystemTime};
-
-    macro_rules! data {
-        ($name:expr) => {
-            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/", $name)
-        };
-    }
-
-    #[test]
-    fn test_read_public_keys() -> Result<()> {
-        let path = Path::new(data!("authorized_keys"));
-
-        let filter = IdentityFilter::from_files(path, None)?;
-
-        // authorized_keys contains the certificate authority key for the CERT_STR cert
-        let cert = Certificate::from_openssh(CERT_STR)?;
-        let identity: Identity = cert.into();
-        assert!(filter.filter(&identity));
-
-        // verify that when using the ca_keys_file parameter, we can use he raw key and don't need
-        // the 'cert-authority ' prefix.
-        let filter = IdentityFilter::from_files(
-            // an empty file works for our purposes
-            Path::new("/dev/null"),
-            Some(Path::new(data!("ca_key.pub"))),
-        )?;
-        assert!(filter.filter(&identity));
-
-        Ok(())
-    }
-
-    const CERT_STR: &str = include_str!(data!("cert.pub"));
 
     #[test]
     fn test_parse_cert() -> Result<()> {

--- a/src/expansions.rs
+++ b/src/expansions.rs
@@ -6,15 +6,15 @@ use uzers::get_user_by_name;
 use uzers::os::unix::UserExt;
 
 pub trait Environment {
-    fn get_homedir(&self, user: &str) -> Result<Cow<str>>;
+    fn get_homedir(&'_ self, user: &str) -> Result<Cow<'_, str>>;
 
-    fn get_username(&self) -> Result<Cow<str>>;
+    fn get_username(&'_ self) -> Result<Cow<'_, str>>;
 
-    fn get_hostname(&self) -> Result<Cow<str>>;
+    fn get_hostname(&'_ self) -> Result<Cow<'_, str>>;
 
-    fn get_fqdn(&self) -> Result<Cow<str>>;
+    fn get_fqdn(&'_ self) -> Result<Cow<'_, str>>;
 
-    fn get_uid(&self) -> Result<Cow<str>>;
+    fn get_uid(&'_ self) -> Result<Cow<'_, str>>;
 }
 
 pub struct UnixEnvironment<'a> {
@@ -28,14 +28,14 @@ impl<'a> UnixEnvironment<'a> {
 }
 
 impl Environment for UnixEnvironment<'_> {
-    fn get_homedir(&self, user: &str) -> Result<Cow<str>> {
+    fn get_homedir(&'_ self, user: &str) -> Result<Cow<'_, str>> {
         match get_user_by_name(user) {
             Some(user) => Ok(Cow::Owned(user.home_dir().to_string_lossy().to_string())),
             None => Err(anyhow!("homedir for {} not found", user)),
         }
     }
 
-    fn get_username(&self) -> Result<Cow<str>> {
+    fn get_username(&'_ self) -> Result<Cow<'_, str>> {
         let service = match self.pam_handle.get_item::<RUser>() {
             Ok(Some(service)) => service,
             _ => {
@@ -49,7 +49,7 @@ impl Environment for UnixEnvironment<'_> {
         ))
     }
 
-    fn get_hostname(&self) -> Result<Cow<str>> {
+    fn get_hostname(&'_ self) -> Result<Cow<'_, str>> {
         let hostname = get_hostname()?;
         let hostname = hostname
             .split('.')
@@ -58,11 +58,11 @@ impl Environment for UnixEnvironment<'_> {
         Ok(Cow::from(hostname.to_string()))
     }
 
-    fn get_fqdn(&self) -> Result<Cow<str>> {
+    fn get_fqdn(&'_ self) -> Result<Cow<'_, str>> {
         Ok(Cow::from(get_hostname()?))
     }
 
-    fn get_uid(&self) -> Result<Cow<str>> {
+    fn get_uid(&'_ self) -> Result<Cow<'_, str>> {
         let username = self.get_username()?;
         let user = get_user_by_name(&username as &str)
             .ok_or_else(|| anyhow!("Failed to look up user with username {}", username))?;
@@ -209,7 +209,7 @@ mod tests {
             }
         }
 
-        fn answer(&self) -> Result<Cow<str>> {
+        fn answer(&'_ self) -> Result<Cow<'_, str>> {
             Ok(Cow::from(
                 self.answers.borrow_mut().pop_front().unwrap().to_string(),
             ))
@@ -217,23 +217,23 @@ mod tests {
     }
 
     impl Environment for DummyEnv {
-        fn get_homedir(&self, _user: &str) -> Result<Cow<str>> {
+        fn get_homedir(&'_ self, _user: &str) -> Result<Cow<'_, str>> {
             self.answer()
         }
 
-        fn get_username(&self) -> Result<Cow<str>> {
+        fn get_username(&'_ self) -> Result<Cow<'_, str>> {
             self.answer()
         }
 
-        fn get_hostname(&self) -> Result<Cow<str>> {
+        fn get_hostname(&'_ self) -> Result<Cow<'_, str>> {
             self.answer()
         }
 
-        fn get_fqdn(&self) -> Result<Cow<str>> {
+        fn get_fqdn(&'_ self) -> Result<Cow<'_, str>> {
             self.answer()
         }
 
-        fn get_uid(&self) -> Result<Cow<str>> {
+        fn get_uid(&'_ self) -> Result<Cow<'_, str>> {
             self.answer()
         }
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,97 @@
+use anyhow::Context;
+use log::debug;
+use ssh_agent_client_rs::Identity;
+use ssh_agent_client_rs::Identity::{Certificate, PublicKey};
+use ssh_key::public::KeyData;
+use ssh_key::AuthorizedKeys;
+use std::collections::HashSet;
+use std::path::Path;
+
+pub struct IdentityFilter {
+    keys: HashSet<KeyData>,
+    ca_keys: HashSet<KeyData>,
+}
+
+impl IdentityFilter {
+    pub fn from_files(path: &Path, ca_keys_file: Option<&Path>) -> anyhow::Result<Self> {
+        let mut keys: HashSet<KeyData> = HashSet::new();
+        let mut ca_keys: HashSet<KeyData> = HashSet::new();
+
+        for entry in
+            AuthorizedKeys::read_file(path).context(format!("Failed to read from {path:?}"))?
+        {
+            let opts = entry.config_opts();
+            if opts.iter().any(|o| o == "cert-authority") {
+                ca_keys.insert(entry.public_key().key_data().to_owned());
+            } else {
+                keys.insert(entry.public_key().key_data().to_owned());
+            }
+        }
+
+        if let Some(key_path) = ca_keys_file {
+            for entry in AuthorizedKeys::read_file(key_path)
+                .context(format!("Failed to read trusted ca keys from {key_path:?}"))?
+            {
+                ca_keys.insert(entry.public_key().key_data().to_owned());
+            }
+        }
+        Ok(IdentityFilter { keys, ca_keys })
+    }
+
+    pub fn filter(&self, identity: &Identity) -> bool {
+        match identity {
+            PublicKey(key) => {
+                if self.keys.contains(key.key_data()) {
+                    debug!(
+                        "found a matching key: {}",
+                        key.fingerprint(Default::default())
+                    );
+                    return true;
+                }
+            }
+            Certificate(cert) => {
+                let ca_key = cert.signature_key();
+                if self.ca_keys.contains(ca_key) {
+                    debug!(
+                        "found a matching cert-authority key: {}",
+                        ca_key.fingerprint(Default::default())
+                    );
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::filter::IdentityFilter;
+    use crate::test::{data, CERT_STR};
+    use ssh_agent_client_rs::Identity;
+    use ssh_key::Certificate;
+    use std::path::Path;
+
+    #[test]
+    fn test_read_public_keys() -> anyhow::Result<()> {
+        let path = Path::new(data!("authorized_keys"));
+
+        let filter = IdentityFilter::from_files(path, None)?;
+
+        // authorized_keys contains the certificate authority key for the CERT_STR cert
+        let cert = Certificate::from_openssh(CERT_STR)?;
+        let identity: Identity = cert.into();
+        assert!(filter.filter(&identity));
+
+        // verify that when using the ca_keys_file parameter, we can use he raw key and don't need
+        // the 'cert-authority ' prefix.
+        let filter = IdentityFilter::from_files(
+            // an empty file works for our purposes
+            Path::new("/dev/null"),
+            Some(Path::new(data!("ca_key.pub"))),
+        )?;
+        assert!(filter.filter(&identity));
+
+        Ok(())
+    }
+}

--- a/src/pam.rs
+++ b/src/pam.rs
@@ -1,0 +1,2 @@
+use pam::module::PamHandle;
+

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,12 @@
+// Some common stuff for unit tests. The top level mod statement
+// is gated in a #[cfg(test)] so we don't need to do that for everything
+// in this module
+
+macro_rules! data {
+    ($name:expr) => {
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/", $name)
+    };
+}
+pub(crate) use data;
+
+pub(crate) const CERT_STR: &str = include_str!(data!("cert.pub"));


### PR DESCRIPTION
In preparation for adding some new features, this change simplifies authenticate() function by passing in an &IdentityFilter.

Also, rustc has gotten some new ideas on declaring lifetimes explicitly, adding that to shut up the warnings.

As I moved some tests around, I realised that I wanted to have a central place for test stuff