### PR TITLE
Change variable expansion to user PAM_USER instead of PAM_RUSER

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ management systems, it might make more sense to move the complexity of using the
 to those systems, but these variable expansions are available to uses that might want them to provide a smooth upgrade
 path from `pam_ssh_agent_auth`.
 
-* `~` same as in shells, without specifying a username this expands to the home directory referred to by `PAM_RUSER`, 
+* `~` same as in shells, without specifying a username this expands to the home directory referred to by `PAM_USER`, 
   normally the user attempting to authenticate. If a username is specified, the home directory of that user will be
   used such that `~alice` might expand to `/home/alice`
-* `%h` same as `~`, the home directory of the user referred to by the PAM item `PAM_RUSER`
+* `%h` same as `~`, the home directory of the user referred to by the PAM item `PAM_USER`
 * `%H` the value returned by `gethostname(3)`, truncated after the first period such that if `gethostname(3)` returns
   `host.example.com` this `%H` will turn into `host`
 * `%f` the value returned by `gethostname(3)`. For the systems I have looked at, this value is not a fully qualified

--- a/src/pamext.rs
+++ b/src/pamext.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow, Result};
-use pam::items::{RUser, Service};
+use pam::items::{Service, User};
 use pam::module::PamHandle;
 use std::borrow::Cow;
 
 pub trait PamHandleExt {
-    /// Fetch the PAM_RUSER value.
+    /// Fetch the PAM_USER value.
     fn get_calling_user(&self) -> Result<Cow<'_, str>>;
 
     /// Fetch the name of the current service, i.e. the software that uses pam for authentication
@@ -27,6 +27,6 @@ macro_rules! get_item {
 }
 
 impl PamHandleExt for PamHandle {
-    get_item!(get_calling_user, RUser);
+    get_item!(get_calling_user, User);
     get_item!(get_service, Service);
 }


### PR DESCRIPTION
This change aligns the semantics with how pam_ssh_agent_auth expands variables and since sudo sets both PAM_USER and PAM_RUSER to the calling user, for a vast majority of users this change should be completely transparent.

See the issue referenced below for a complete discussion

Closes: #62