### PR TITLE
Install into /usr/lib instead of /lib

### DIFF
--- a/debian/pam-ssh-agent.install
+++ b/debian/pam-ssh-agent.install
@@ -1,1 +1,1 @@
-target/release/pam_ssh_agent.so /lib/${DEB_HOST_MULTIARCH}/security
+target/release/pam_ssh_agent.so /usr/lib/${DEB_HOST_MULTIARCH}/security


### PR DESCRIPTION
The lintian in Ubuntu resolute is a bit pickier than the one before