### PR TITLE
macOS support and audit fixes

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,103 @@
+# macOS debug & audit of `pam-ssh-agent`
+
+This document records an audit of `pam-ssh-agent` aimed at making the module build and load on
+**macOS** (which uses OpenPAM, not Linux-PAM) and reviewing the authentication / certificate /
+verification logic for correctness. The changes in this branch are rebased onto upstream
+`main` (v0.9.7).
+
+> A fourth issue found during the audit — certificates were not checked to be *user*
+> certificates — was **independently fixed upstream** in commit `8e21d5e` ("Ensure that only
+> user certificates can be used to authenticate") while this work was in progress, so it is not
+> included here.
+
+## Environment & verification
+
+Performed on macOS (Apple Silicon), MSRV 1.88 / toolchain per `rust-toolchain.toml`. Both
+crypto backends were built and tested:
+
+| Check | Result |
+|-------|--------|
+| `cargo build` (default, pure-Rust) | ✅ produces `target/debug/libpam_ssh_agent.dylib` |
+| `cargo test --no-default-features` | ✅ pass |
+| `cargo test --no-default-features --features native-crypto` | ✅ pass (OpenSSL) |
+| `cargo fmt --check` | ✅ clean |
+| `cargo clippy --no-deps` | ✅ clean |
+
+Not exercised here: loading the built `.dylib` into a live OpenPAM stack and authenticating
+end-to-end. That depends on local PAM configuration; steps are in `README.md` → "Building and
+installing on macOS".
+
+## Findings & fixes
+
+### FIX 1 — macOS cdylib fails to link (platform blocker) — High
+* **Where:** build/link layer; `Cargo.toml` declares the module as a `cdylib`.
+* **Platform:** macOS only.
+* **Problem:** the module references PAM symbols (`pam_get_item`, …) that the loader supplies
+  at runtime. The macOS linker refuses undefined symbols by default, so the build fails with
+  `Undefined symbols: _pam_get_item`. (The GNU linker on Linux tolerates this, which is why CI
+  — Ubuntu only — never caught it.)
+* **Fix:** added `build.rs` that, on macOS only, emits
+  `cargo::rustc-link-arg-cdylib=-Wl,-undefined,dynamic_lookup`. Scoped to the cdylib and to
+  macOS, so the `lib`/test builds and Linux/CI are unaffected.
+* **Verified:** the `.dylib` now links and is produced on macOS.
+
+### FIX 2 — logging setup denies authentication when syslog is unavailable — High (availability)
+* **Where:** `src/lib.rs::run` (call site) → `src/logging.rs::init_logging` / `init_impl`.
+* **Platform:** any host where the syslog socket can't be opened; more likely on macOS.
+* **Problem:** `run()` called `init_logging(...)?`. `init_impl` hard-errors if `syslog::unix()`
+  cannot connect to `/dev/log`, `/var/run/syslog`, or `/var/run/log`. That error propagated to
+  `PAM_AUTH_ERR`, so a logging-setup failure failed **every** authentication closed (lockout).
+* **Fix:** `init_logging` is now best-effort at the call site — on failure we write a line to
+  stderr and continue. A logging problem can no longer gate authentication. `init_logging`
+  keeps its `Result` and idempotency contract; only the call site stops treating failure as
+  fatal.
+
+### FIX 4 — `SSH_AUTH_INFO_0` was parsed incorrectly for the sshd special case — Medium (correctness)
+* **Where:** `src/lib.rs::check_sshd_special_case`.
+* **Platform:** all.
+* **Problem:** the code ran `PublicKey::from_openssh()` on the raw `SSH_AUTH_INFO_0` value, but
+  `sshd` formats each entry with a leading method token, e.g. `publickey ssh-ed25519 AAAA…`.
+  Parsing always failed, so the documented sshd "`sufficient`" shortcut never fired — and worse,
+  the parse error propagated, short-circuiting the normal challenge-response path too.
+  (Fail-safe: a `sufficient` module that errors is skipped by PAM, so it was a broken feature,
+  not a bypass.) Certificates were not handled.
+* **Fix:** strip the leading `publickey ` token (tolerating its absence), iterate newline
+  entries, and parse each as a certificate or a plain public key based on the key type. Parse
+  failures are now **non-fatal** — logged and skipped, falling back to normal challenge-response.
+  Certificates are routed through the full `validate_cert` check (window, CA, principal, type)
+  so the shortcut is never weaker than the main path; the calling user is threaded in as the
+  principal. This requires exposing `validate_cert` (`pub(crate)`) from `src/auth.rs`.
+* **Test:** `tests::test_check_sshd_special_case` covers a matching `publickey` entry, an
+  untrusted key, non-`sshd` services, an unparseable (non-fatal) entry, and a CA-trusted but
+  expired certificate that is correctly rejected.
+
+## Reviewed and assessed OK (no change)
+
+* **Challenge-response core** (`src/auth.rs::authenticate` / `sign_and_verify`): signs a fresh
+  32-byte random challenge from `getrandom` and verifies the signature locally; a
+  `RemoteFailure` (e.g. an `sk`/hardware key not present) is non-fatal and moves to the next
+  key. Sound.
+* **Certificate validation** (`src/auth.rs::validate_cert`): window, CA-fingerprint signature,
+  user-cert type (upstream `8e21d5e`), principal membership, and empty critical options all
+  enforced.
+* **Crypto-backend parity** (`src/verify.rs` ↔ `src/nativecrypto.rs`): both paths cover
+  Ed25519, ECDSA P-256/384/521, and RSA-SHA256/512, and fail closed otherwise.
+* **Home-directory expansion** (`src/expansions.rs`): `~`/`%h` is intentionally unsafe and
+  documented as such; left unchanged by design.
+
+## Notes
+
+* **PAM result-code numbering** differs between Linux-PAM and OpenPAM, and `pam-bindings` uses
+  the Linux values. This is fail-safe for this module: only the happy path returns
+  `PAM_SUCCESS` (`0`, which agrees across both), and every error path collapses to a non-zero
+  failure code, which PAM treats as "not success" regardless of the exact number. The
+  `PAM_USER` / `PAM_SERVICE` item selectors used in `src/pamext.rs` agree across both
+  implementations. No change required; documented for reviewers.
+
+## Remaining (user, on a Mac)
+
+1. Build the release dylib and install per `README.md` → "Building and installing on macOS".
+2. Wire it into a test `/etc/pam.d` service (e.g. `sudo_local`) and authenticate via
+   Secretive's agent (`SSH_AUTH_SOCK`).
+3. Optionally confirm FIX 2 by making the syslog socket unavailable and verifying that
+   authentication still succeeds.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,36 @@ For other users, it is entirely possible to simply invoke `cargo build --release
 `target/release/libpam_ssh_agent.so` to the directory that holds your pam modules. Mine is in 
 `/lib/x86_64-linux-gnu/security`.
 
+### Building and installing on macOS
+
+This module also builds and runs on macOS, which uses OpenPAM rather than Linux-PAM. A few
+things differ from Linux:
+
+* `cargo build --release` produces a **`.dylib`**, not a `.so`:
+  `target/release/libpam_ssh_agent.dylib`. The bundled `build.rs` automatically passes the
+  `-undefined dynamic_lookup` linker flag that macOS requires for a PAM module — the `pam_*`
+  symbols are resolved by the PAM runtime at load time, and without the flag the link fails
+  with `Undefined symbols: _pam_get_item`.
+* Apple's System Integrity Protection makes `/usr/lib/pam` read-only, so install the module
+  elsewhere and refer to it by **absolute path**:
+  ```sh
+  cargo build --release
+  sudo mkdir -p /usr/local/lib/pam
+  sudo cp target/release/libpam_ssh_agent.dylib /usr/local/lib/pam/pam_ssh_agent.so
+  ```
+  (OpenPAM loads Mach-O modules that conventionally carry a `.so` name.)
+* Wire it into a service under `/etc/pam.d`. On recent macOS the clean way to add it to
+  `sudo` is `/etc/pam.d/sudo_local` (copy it from `/etc/pam.d/sudo_local.template`):
+  ```
+  auth  sufficient  /usr/local/lib/pam/pam_ssh_agent.so  file=/etc/security/authorized_keys
+  ```
+* Use an `ssh-agent` that exposes a Secure Enclave key such as
+  [Secretive](https://github.com/maxgoedjen/secretive), and make sure `SSH_AUTH_SOCK` is set
+  in the environment that runs `sudo`.
+
+> The build and the full test suite (both crypto backends) pass on macOS. Verify the runtime
+> PAM load on your own machine, since PAM integration depends on local configuration.
+
 ## Example Usage
 
 * First, install the software using one of the methods above.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+// Build script.
+//
+// On macOS the module is loaded by the OpenPAM runtime, which provides the `pam_*`
+// symbols (pam_get_item, etc.) at load time. The macOS linker, unlike the GNU linker
+// used on Linux, refuses to produce a dynamic library with unresolved symbols by
+// default and the build fails with "Undefined symbols: _pam_get_item". Tell the macOS
+// linker to defer those symbols to dynamic lookup at load time.
+//
+// This is scoped to the cdylib artifact and to macOS only, so it has no effect on the
+// `lib`/test builds or on Linux (including CI).
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo::rustc-link-arg-cdylib=-Wl,-undefined,dynamic_lookup");
+    }
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -58,7 +58,11 @@ fn sign_and_verify(identity: Identity<'static>, agent: &mut impl SSHAgent) -> Re
     Ok(true)
 }
 
-fn validate_cert(cert: &ssh_key::Certificate, when: SystemTime, principal: &str) -> bool {
+pub(crate) fn validate_cert(
+    cert: &ssh_key::Certificate,
+    when: SystemTime,
+    principal: &str,
+) -> bool {
     let ca_key = cert.signature_key();
 
     if let Err(e) = cert.validate_at(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod verify;
 
 pub use crate::agent::SSHAgent;
 pub use crate::auth::authenticate;
+use crate::auth::validate_cert;
 use pam::constants::{PamFlag, PamResultCode};
 use pam::module::{PamHandle, PamHooks};
 use std::env;
@@ -24,13 +25,14 @@ use crate::environment::{Environment, UnixEnvironment};
 use crate::filter::IdentityFilter;
 use crate::logging::init_logging;
 use crate::pamext::PamHandleExt;
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use args::Args;
 use log::{debug, error, info};
-use ssh_agent_client_rs::Client;
-use ssh_key::PublicKey;
+use ssh_agent_client_rs::{Client, Identity};
+use ssh_key::{Certificate, PublicKey};
 use std::ffi::CStr;
 use std::path::Path;
+use std::time::SystemTime;
 
 struct PamSshAgent;
 pam::pam_hooks!(PamSshAgent);
@@ -77,7 +79,12 @@ impl PamHooks for PamSshAgent {
 }
 
 fn run(args: Vec<&CStr>, pam_handle: &PamHandle) -> Result<()> {
-    init_logging(pam_handle.get_service().unwrap_or("unknown".into()))?;
+    // A logging-setup failure must never deny authentication: on some platforms (e.g.
+    // macOS) the syslog socket probed by init_logging() may be unavailable, and
+    // propagating that error would fail every authentication closed. Best-effort instead.
+    if let Err(e) = init_logging(pam_handle.get_service().unwrap_or("unknown".into())) {
+        eprintln!("pam_ssh_agent: failed to initialize logging: {e:?}");
+    }
     let args = Args::parse(args, &UnixEnvironment, pam_handle)?;
     if args.debug {
         log::set_max_level(log::LevelFilter::Debug);
@@ -111,7 +118,12 @@ fn do_authenticate(args: &Args, handle: &PamHandle) -> Result<()> {
         &calling_user,
     )?;
 
-    if check_sshd_special_case(handle.get_service().ok(), &filter, UnixEnvironment)? {
+    if check_sshd_special_case(
+        handle.get_service().ok(),
+        &filter,
+        UnixEnvironment,
+        &calling_user,
+    )? {
         return Ok(());
     }
     match authenticate(&filter, ssh_agent_client, &handle.get_calling_user()?)? {
@@ -120,12 +132,21 @@ fn do_authenticate(args: &Args, handle: &PamHandle) -> Result<()> {
     }
 }
 
-/// Returns true if SSH_SERVICE is sshd, and the environment variable SSH_AUTH_INFO_0 is set
-/// to a public key that filter is configured with.
+/// Implements the sshd special case: when the calling service is `sshd`, the environment
+/// variable `SSH_AUTH_INFO_0` holds the key(s) sshd used for its own publickey
+/// authentication. If one of them is trusted by `filter` (and, for a certificate, also
+/// passes full certificate validation) this returns true and authentication succeeds
+/// without a fresh challenge-response round.
+///
+/// sshd formats each entry as a line led by the method name, e.g.
+/// `publickey ssh-ed25519 AAAA...` or `publickey ssh-ed25519-cert-v01@openssh.com AAAA...`.
+/// A parse failure for any entry is non-fatal: the entry is skipped and authentication
+/// falls back to the normal challenge-response path rather than being denied.
 fn check_sshd_special_case(
     service: Option<String>,
     filter: &IdentityFilter,
     env: impl Environment,
+    principal: &str,
 ) -> Result<bool> {
     match service {
         Some(service) => {
@@ -135,15 +156,49 @@ fn check_sshd_special_case(
         }
         None => return Ok(false),
     }
-    let Some(key) = env.get_env("SSH_AUTH_INFO_0") else {
+    let Some(info) = env.get_env("SSH_AUTH_INFO_0") else {
         debug!("calling service is sshd but SSH_AUTH_INFO_0 is not set");
         return Ok(false);
     };
-    Ok(filter.filter(
-        &PublicKey::from_openssh(&key)
-            .context("failed to parse key in SSH_AUTH_INFO_0 environment variable")?
-            .into(),
-    ))
+    for line in info.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // Drop the leading method token ("publickey ") if present; tolerate its absence.
+        let entry = line.strip_prefix("publickey ").unwrap_or(line);
+        let identity = match parse_auth_info_identity(entry) {
+            Ok(identity) => identity,
+            Err(e) => {
+                debug!("failed to parse SSH_AUTH_INFO_0 entry: {e:?}");
+                continue;
+            }
+        };
+        if !filter.filter(&identity) {
+            continue;
+        }
+        match &identity {
+            Identity::Certificate(cert) => {
+                if validate_cert(cert, SystemTime::now(), principal) {
+                    return Ok(true);
+                }
+            }
+            Identity::PublicKey(_) => return Ok(true),
+        }
+    }
+    Ok(false)
+}
+
+/// Parse a single `SSH_AUTH_INFO_0` entry (with the leading method token already removed)
+/// into an [`Identity`], choosing a certificate or a plain public key based on the key
+/// type token.
+fn parse_auth_info_identity(entry: &str) -> Result<Identity<'static>> {
+    let key_type = entry.split_whitespace().next().unwrap_or_default();
+    if key_type.ends_with("-cert-v01@openssh.com") {
+        Ok(Certificate::from_openssh(entry)?.into())
+    } else {
+        Ok(PublicKey::from_openssh(entry)?.into())
+    }
 }
 
 fn get_path(args: &Args) -> Result<String> {
@@ -167,48 +222,71 @@ fn get_path(args: &Args) -> Result<String> {
 mod tests {
     use crate::check_sshd_special_case;
     use crate::filter::IdentityFilter;
-    use crate::test::{CannedEnv, DummyEnv, data};
+    use crate::test::{CERT_STR, CannedEnv, DummyEnv, data};
     use anyhow::Result;
     use std::path::Path;
+
+    // SSH_AUTH_INFO_0-style entries (method token + key) as sshd would set them.
+    const AUTH_INFO_MATCHING: &str = "publickey ssh-ed25519 \
+        AAAAC3NzaC1lZDI1NTE5AAAAIObUcRy1Nv6fz4xnAXqOaFL/A+gGM9OF+l2qpsDPmMlU test@ed25519";
+    const AUTH_INFO_OTHER: &str = "publickey ssh-ed25519 \
+        AAAAC3NzaC1lZDI1NTE5AAAAIBEnbbUON/7pV3uMtWfP3eWk9xGVa7qhEb50a5p0zDSk test-ca-key";
 
     #[test]
     fn test_check_sshd_special_case() -> Result<()> {
         let key = Path::new(data!("id_ed25519.pub"));
         let filter = IdentityFilter::from_authorized_file(key)?;
 
-        // happy path, keys match
+        // happy path: a "publickey <type> <b64>" entry matching a trusted key
         assert!(check_sshd_special_case(
             Some("sshd".to_string()),
             &filter,
-            CannedEnv::new(vec![include_str!(data!("id_ed25519.pub"))])
+            CannedEnv::new(vec![AUTH_INFO_MATCHING]),
+            "principal",
         )?);
 
-        // different key
+        // a different, untrusted key
         assert!(!check_sshd_special_case(
             Some("sshd".to_string()),
             &filter,
-            CannedEnv::new(vec![include_str!(data!("ca_key.pub"))])
+            CannedEnv::new(vec![AUTH_INFO_OTHER]),
+            "principal",
         )?);
 
-        // if service is not set, return false
-        assert!(!check_sshd_special_case(None, &filter, DummyEnv)?);
+        // if service is not set, return false (env is never consulted)
+        assert!(!check_sshd_special_case(
+            None,
+            &filter,
+            DummyEnv,
+            "principal"
+        )?);
 
-        // if service is not set to something other than sshd, return false
+        // if service is something other than sshd, return false
         assert!(!check_sshd_special_case(
             Some("something".to_string()),
             &filter,
-            DummyEnv
+            DummyEnv,
+            "principal",
         )?);
 
-        // not a key
-        assert!(
-            check_sshd_special_case(
-                Some("sshd".to_string()),
-                &filter,
-                CannedEnv::new(vec!["invalid"])
-            )
-            .is_err()
-        );
+        // an unparseable entry is non-fatal: no match, but not an error
+        assert!(!check_sshd_special_case(
+            Some("sshd".to_string()),
+            &filter,
+            CannedEnv::new(vec!["invalid"]),
+            "principal",
+        )?);
+
+        // a CA-trusted but expired certificate: the filter matches it, but full cert
+        // validation rejects it, so the result is false (exercises the certificate path)
+        let cert_filter =
+            IdentityFilter::from_authorized_file(Path::new(data!("authorized_keys")))?;
+        assert!(!check_sshd_special_case(
+            Some("sshd".to_string()),
+            &cert_filter,
+            CannedEnv::new(vec![CERT_STR]),
+            "principal",
+        )?);
 
         Ok(())
     }


### PR DESCRIPTION
Adds macOS support and two correctness fixes found while auditing the module for macOS (which uses OpenPAM). Full write-up in `AUDIT.md`.

## Changes

- **macOS build (`build.rs`):** the `cdylib` references PAM symbols that the loader resolves at runtime; the macOS linker rejects undefined symbols by default, so the build fails with `Undefined symbols: _pam_get_item`. A build script emits `-undefined dynamic_lookup` for the cdylib on macOS only (no effect on Linux/CI). The release build then produces `libpam_ssh_agent.dylib`.
- **Logging must not deny auth (`src/lib.rs`):** `run()` propagated `init_logging` failures up to `PAM_AUTH_ERR`, so if the syslog socket is unavailable (more likely on macOS) *every* authentication failed closed. Logging init is now best-effort.
- **sshd `SSH_AUTH_INFO_0` parsing (`src/lib.rs`):** the value is an authorized_keys-style entry led by the method token (`publickey ssh-ed25519 AAAA…`), which `PublicKey::from_openssh` rejected — so the documented sshd `sufficient` shortcut never fired, and the parse error short-circuited the normal challenge-response path too. It now strips the method token, iterates entries, routes certificates through the full `validate_cert` check, and treats parse failures as non-fatal. (`validate_cert` is now `pub(crate)`.)
- **README:** "Building and installing on macOS" section.

## Notes

- The "only user certificates may authenticate" issue I also found during the audit is already fixed on `main` (`8e21d5e`), so it is intentionally not included here.
- Verified on macOS: `cargo build`, `cargo fmt --check`, `cargo clippy --no-deps`, and the test suite under **both** the pure-Rust and `native-crypto` (OpenSSL) backends. The runtime PAM load into a live OpenPAM stack was not exercised (depends on local configuration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
